### PR TITLE
Project hygiene

### DIFF
--- a/Client.cs
+++ b/Client.cs
@@ -58,11 +58,11 @@ namespace Riemann {
 		/// <param name='port'>Port to connect to. Default: 5555</param>
 		/// <param name='throwExceptionOnTicks'>Throw an exception on the background thread managing the TickEvents. Default: true</param>
 		///
-		public Client(string host = "localhost", ushort port = 5555, bool throwExceptionOnTicks = true) {
+		public Client(string host = "localhost", int port = 5555, bool throwExceptionOnTicks = true) {
 			_writer = new Lazy<Stream>(MakeStream);
 			_datagram = new Lazy<Socket>(MakeDatagram);
 			_host = host;
-			_port = port;
+			_port = (ushort)port;
 			_throwExceptionsOnTicks = throwExceptionOnTicks;
 		}
 

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -18,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("1110037b-fd8e-421a-a7cf-23a4c6eb9b28")]

--- a/Riemann.csproj
+++ b/Riemann.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -41,10 +42,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Project hygiene
- remove unused refs to System.Data.DataSetExtensions, System.Data,System.Linq.Xml
- warnings as errors
- mark as CLSCompliant so that it can be used in VB.Net and other .Net languages. And change expose ushort to int as this is not cls compliant as per http://stackoverflow.com/questions/3475726/argument-type-is-not-cls-compliant-why
