### PR TITLE
Allow tags to be specified from Events

### DIFF
--- a/Client.cs
+++ b/Client.cs
@@ -210,18 +210,24 @@ namespace Riemann {
 				}
 			}
 			var protoEvents = events.Select(
-				e => new Proto.Event {
-					host = _name,
-					service = e.Service,
-					state = e.State,
-					description = e.Description,
-					metric_f = e.Metric,
-					ttl = e.TTL
+				e =>  {
+                    var evnt = new Proto.Event
+                    {
+                        host = _name,
+                        service = e.Service,
+                        state = e.State,
+                        description = e.Description,
+                        metric_f = e.Metric,
+                        ttl = e.TTL
+                    };
+                    evnt.tags.AddRange(e.Tags);
+                    return evnt;
 				}).ToList();
 
-			var message = new Proto.Msg();			
+			var message = new Proto.Msg();
 			foreach (var protoEvent in protoEvents) {
-				protoEvent.tags.AddRange(tags);
+                if(protoEvent.tags.Count == 0)
+				    protoEvent.tags.AddRange(tags);
 				message.events.Add(protoEvent);
 			}
 			var memoryStream = new MemoryStream();

--- a/Event.cs
+++ b/Event.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Riemann {
 	///
@@ -30,7 +31,11 @@ namespace Riemann {
 		///
 		public readonly int TTL;
 
-	        ///
+        /// 
+        /// <summary>Freeform list of strings, will override the tags set from the Client</summary>
+        /// 
+        public readonly IList<string> Tags;
+
 		/// <summary>Constructs an event</summary>
 		/// <param name="service">Service name</param>
 		/// <param name="state">Current status of the service.</param>
@@ -48,6 +53,7 @@ namespace Riemann {
 			Description = description;
 			Metric = metric;
 			TTL = ttl;
+            Tags = new List<string>();
 		}
 	}
 }


### PR DESCRIPTION
Currently we can set tags from the Client, however I've found it useful to be able to specify tags at the Event level and then have those tags override the defaults specified on the client
